### PR TITLE
Improve docker-compose.prod.yml: network isolation and container names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ POSTGRES_PASSWORD=changeme
 # Redis (overridden by docker-compose.prod.yml when running in Docker)
 REDIS_URL=redis://localhost:6379
 
+# Eversolo streamer local IP (optional — enables now-playing integration)
+EVERSOLO_HOST=
+
 # New releases window in days (default: 90)
 NEW_RELEASES_DAYS_WINDOW=90
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,7 @@
 services:
   app:
     image: ghcr.io/rogertinsley/encore:latest
+    container_name: encore
     ports:
       - "3567:3567"
     env_file:
@@ -26,9 +27,13 @@ services:
       cache:
         condition: service_healthy
     restart: unless-stopped
+    networks:
+      - internal
+      - default
 
   db:
     image: postgres:16-alpine
+    container_name: encore-db
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
@@ -37,23 +42,32 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-encore}"]
-      interval: 5s
+      interval: 10s
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    networks:
+      - internal
 
   cache:
     image: redis:7-alpine
+    container_name: encore-cache
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
+      interval: 10s
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    networks:
+      - internal
 
 volumes:
   postgres_data:
   redis_data:
+
+networks:
+  internal:
+    internal: true


### PR DESCRIPTION
## Summary

- **Network isolation**: adds an `internal` network so `db` and `cache` are unreachable from outside the compose project. Only `app` joins `default` (the externally-accessible network). Previously all three services shared the default bridge, meaning postgres and redis ports were theoretically reachable by other containers on the host.
- **Explicit container names**: `encore`, `encore-db`, `encore-cache` — makes `docker logs encore-db` and `docker exec encore` work without guessing the auto-generated name.
- **Healthcheck interval 5s → 10s**: reduces log noise during slow starts; still fails fast enough to be useful.
- **`EVERSOLO_HOST` added to `.env.example`**: this env var is consumed by the app but was absent from the example file, making it a hidden configuration option for anyone self-hosting.

## Test plan

- [ ] `docker compose -f docker-compose.prod.yml up -d` starts all three containers cleanly
- [ ] App is reachable on port 3567
- [ ] `docker exec encore-db psql ...` works by name
- [ ] `docker network inspect` confirms db/cache are on `internal` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)